### PR TITLE
Constraint and Or Graders

### DIFF
--- a/src/ConstraintGrader.fun
+++ b/src/ConstraintGrader.fun
@@ -5,8 +5,7 @@ functor ConstraintGrader (structure Constraint : GRADER
   struct
     structure Rubric =
       struct
-        val description = "ConstraintGrader: " ^ Constraint.Rubric.description
-                            ^ " and " ^ Standard.Rubric.description
+        val description = Standard.Rubric.description
 
         datatype t = Violation
                    | Result of Standard.Rubric.t

--- a/src/ConstraintGrader.fun
+++ b/src/ConstraintGrader.fun
@@ -1,0 +1,29 @@
+functor ConstraintGrader (structure Constraint : GRADER
+                          structure Standard : GRADER
+                          val threshold : Rational.t
+                          val message : string) :> GRADER =
+  struct
+    structure Rubric =
+      struct
+        val description = "ConstraintGrader: " ^ Constraint.Rubric.description
+                            ^ " and " ^ Standard.Rubric.description
+
+        datatype t = Violation
+                   | Result of Standard.Rubric.t
+
+        val toString = fn Violation => message
+                        | Result r  => Standard.Rubric.toString r
+
+        val score = fn Violation => Rational.zero
+                     | Result r  => Standard.Rubric.score r
+      end
+
+    val process = fn () =>
+      let
+        val score = Constraint.Rubric.score (Constraint.process ())
+      in
+        case Rational.compare (threshold, score) of
+          GREATER => Rubric.Violation
+        | _       => Rubric.Result (Standard.process ())
+      end
+  end

--- a/src/OrGrader.fun
+++ b/src/OrGrader.fun
@@ -1,10 +1,10 @@
-functor OrGrader (structure Grader1 : GRADER
+functor OrGrader (val description : string
+                  structure Grader1 : GRADER
                   structure Grader2 : GRADER) :> GRADER =
   struct
     structure Rubric =
       struct
-        val description = "ConstraintGrader: " ^ Constraint.Rubric.description
-                            ^ " and " ^ Standard.Rubric.description
+        val description = description
 
         datatype t = Result1 of Grader1.Rubric.t
                    | Result2 of Grader2.Rubric.t

--- a/src/OrGrader.fun
+++ b/src/OrGrader.fun
@@ -18,10 +18,10 @@ functor OrGrader (structure Grader1 : GRADER
 
     val process = fn () =>
       let
-        val process1 = Grader1.process ()
-        val score1   = Grader1.Rubric.score process1
-        val process2 = Grader2.process ()
-        val score2   = Grader2.Rubric.score process2
+        val rubric1 = Grader1.process ()
+        val score1   = Grader1.Rubric.score rubric1
+        val rubric2 = Grader2.process ()
+        val score2   = Grader2.Rubric.score rubric2
       in
         case Rational.compare (score1, score2) of
           LESS => Rubric.Result2 process2

--- a/src/OrGrader.fun
+++ b/src/OrGrader.fun
@@ -1,0 +1,30 @@
+functor OrGrader (structure Grader1 : GRADER
+                  structure Grader2 : GRADER) :> GRADER =
+  struct
+    structure Rubric =
+      struct
+        val description = "ConstraintGrader: " ^ Constraint.Rubric.description
+                            ^ " and " ^ Standard.Rubric.description
+
+        datatype t = Result1 of Grader1.Rubric.t
+                   | Result2 of Grader2.Rubric.t
+
+        val toString = fn Result1 r => Grader1.Rubric.toString r
+                        | Result2 r => Grader2.Rubric.toString r
+
+        val score = fn Result1 r => Grader1.Rubric.score r
+                     | Result2 r => Grader2.Rubric.score r
+      end
+
+    val process = fn () =>
+      let
+        val process1 = Grader1.process ()
+        val score1   = Grader1.Rubric.score process1
+        val process2 = Grader2.process ()
+        val score2   = Grader2.Rubric.score process2
+      in
+        case Rational.compare (score1, score2) of
+          LESS => Rubric.Result2 process2
+        | _    => Rubric.Result1 process1
+      end
+  end

--- a/src/sources.cm
+++ b/src/sources.cm
@@ -19,6 +19,9 @@ Library
   functor EquivGraderBucketList
   functor EquivGraderList
 
+  functor ConstraintGrader
+  functor OrGrader
+
   functor Preamble
 
   structure FormatUtil
@@ -48,6 +51,9 @@ is
   BucketGrader.fun
   EquivGraderBucket.fun
   EquivGrader.fun
+
+  ConstraintGrader.fun
+  OrGrader.fun
 
   Preamble.fun
 


### PR DESCRIPTION
Adds a constraint grader functor which takes in a Constraint and a Standard grader. When ran, it first checks to make sure the Constraint grader gives a point value above the threshold. If it does then it has the same results as the Standard grader. If not, then it awards zero points and gives some message.

The or grader functor simply takes in two graders and takes the maximal score of the two. Potentially useful for if we want to accept off-by-one errors (so we don't have to make the original grader handle this in some way).